### PR TITLE
add region highlight

### DIFF
--- a/autoload/yankround.vim
+++ b/autoload/yankround.vim
@@ -14,6 +14,7 @@ function! s:_rounder.detect_cursmoved() "{{{
   if getpos('.')==self.pos
     return
   end
+  call s:_rounder.clear_highlight()
   call s:_release_rounder()
 endfunction
 "}}}
@@ -39,8 +40,6 @@ function! s:_rounder.round_cache(incdec) "{{{
   ec 'yankround: ('. (self.idx+1). '/'. self.cachelen. ')'
   let self.pos = getpos('.')
   let self.changedtick = b:changedtick
-
-  call self.highlight_region()
 endfunction
 "}}}
 
@@ -91,6 +90,7 @@ function! yankround#init_rounder(keybind) "{{{
     autocmd!
     autocmd CursorMoved *   call s:rounder.detect_cursmoved()
   aug END
+  call s:rounder.highlight_region()
 endfunction
 "}}}
 function! yankround#prev() "{{{
@@ -129,11 +129,6 @@ endfunction
 function! yankround#_get_cache_and_regtype(idx) "{{{
   let ret = matchlist(g:yankround#cache[a:idx], '^\(.\d*\)\t\(.*\)')
   return [ret[2], ret[1]]
-endfunction
-"}}}
-
-function! yankround#clear_highlight() "{{{
-  call s:_rounder.clear_highlight()
 endfunction
 "}}}
 

--- a/plugin/yankround.vim
+++ b/plugin/yankround.vim
@@ -23,7 +23,6 @@ aug yankround
   autocmd VimLeavePre *   call yankround#persistent()
 aug END
 function! s:append_yankcache() "{{{
-  call yankround#clear_highlight()
   if g:yankround#stop_caching || @" ==# substitute(get(g:yankround#cache, 0, ''), '^.\d*\t', '', '') || @"=~'^.\?$'
     return
   end


### PR DESCRIPTION
yank したtextを Visual でハイライトするようにしました。
yankround-next, yankround-prev でしか試してませんが。

今日ちょっと、使い始めてまだ使い込んでないので動作わかってませんので、取り込むにしても問題ないか確認をお願いしたいです。

あと、regtypeが ^V4 とかの場合は、うまくハイライトできません。
これは matchadd()のパターンをもっと工夫する必要があるので、やってません。
