### PR TITLE
correct typo

### DIFF
--- a/plugin/yankround.vim
+++ b/plugin/yankround.vim
@@ -22,7 +22,7 @@ cnoremap <Plug>(yankround-insert-register)   <C-\>eyankround#cmdline_base()<CR><
 cnoremap <Plug>(yankround-pop)    <C-\>eyankround#cmdline_pop(1)<CR>
 cnoremap <Plug>(yankround-backpop)   <C-\>eyankround#cmdline_pop(-1)<CR>
 
-if get(g:, 'ctrlp_abailable')
+if get(g:, 'ctrlp_available')
   command! -nargs=0   CtrlPYankRound    call ctrlp#init(ctrlp#yankround#id())
 end
 "=============================================================================


### PR DESCRIPTION
This plugin is awesome, but please stop messing with :CtrlPYankRound. 
It used to work always, 
then it needed let g:yankround_use_ctrlp = 1,
now let g:ctrlp_available = 1
but then it doesn't even work if one sets `let g:ctrlp_available`.