### PR TITLE
make ctrlp entries searchable

### DIFF
--- a/autoload/ctrlp/yankround.vim
+++ b/autoload/ctrlp/yankround.vim
@@ -53,10 +53,6 @@ function! s:_cache_to_ctrlpline(str) "{{{
   return strtrans(entry[2])
 endfunction
 "}}}
-function! s:_change_regmodechar(char) "{{{
-  return a:char==#'v' ? 'c' : a:char==#'V' ? 'l' : a:char
-endfunction
-"}}}
 
 "=============================================================================
 "END "{{{1

--- a/autoload/ctrlp/yankround.vim
+++ b/autoload/ctrlp/yankround.vim
@@ -50,7 +50,7 @@ unlet s:CTRLP_BUILTINS
 "======================================
 function! s:_cache_to_ctrlpline(str) "{{{
   let entry = matchlist(a:str, "^\\(.\\d*\\)\t\\(.*\\)")
-  return s:_change_regmodechar(entry[1]). "\t". strtrans(entry[2])
+  return strtrans(entry[2])
 endfunction
 "}}}
 function! s:_change_regmodechar(char) "{{{


### PR DESCRIPTION
this will make fuzzy search compare to the string in the last and not first column that contains the register type. Otherwise only the first column, displaying `c` or `l`, is searched in.