### PR TITLE
add yankround#inactivate()

### DIFF
--- a/autoload/yankround.vim
+++ b/autoload/yankround.vim
@@ -259,6 +259,11 @@ function! yankround#next() "{{{
 endfunction
 "}}}
 
+function! yankround#inactivate() abort
+  if has_key(s:, 'rounder')
+    call s:destroy_rounder()
+  endif
+endfunction
 function! yankround#is_active() "{{{
   return has_key(s:, 'rounder') && s:rounder.is_valid()
 endfunction


### PR DESCRIPTION
Hi :D

I want to a way to inactivate yankround.vim with no cursor moving.
I added a function `yankround#inactivate()` to

```vim
nnoremap <silent> <Esc> :<C-u>call yankround#inactivate()<CR><Esc>
```

Thanks!